### PR TITLE
CASMCMS-7753: Ignore CAPMC errors for nodes that fail to power off

### DIFF
--- a/src/cray/boa/capmcclient.py
+++ b/src/cray/boa/capmcclient.py
@@ -264,6 +264,14 @@ def graceful_shutdown(nodes, grace_window=300, hard_window=180, graceful_prewait
         try:
             failed_nodes_tmp, errors_tmp = power(list(nodes_on), "off",
                                                  force=force, session=session, reason=reason)
+            if attempt == "graceful":
+                # Weed out any nodes that CAPMC said refused to turn off. Those
+                # will be handled during the forceful power off.
+                if "exceeded retries waiting for component to be Off" in errors_tmp:
+                    nodes_failed_to_power_off = set(errors_tmp["exceeded retries waiting for component to be Off"])
+                    failed_nodes_tmp = failed_nodes_tmp - nodes_failed_to_power_off
+                    LOGGER.warn("CAPMC reported these nodes failed to power off. They will be forcefully powered off: {}".format(nodes_failed_to_power_off))
+
         except ValueError as e:
             LOGGER.critical("Error calling 'power': %s", e)
             return nodes_on, errors


### PR DESCRIPTION
## Summary and Scope
This is a bug fix.

CAPMC's behavior changed. It returns an error code when a node fails to
power off. Previously, it did not return an error. BOS handled this
situation by issuing a forceful power off request. This behavior change
causes BOS it ignore the failing node and not issue the forceful power
off request to it. The CAPMC change caused a BOS bug.

To combat this bug, BOS is going to ignore this error message. It will
not weed out the failing nodes and will attempt to issue them the
forceful power off request.

This change is backwards compatible.

## Issues and Related PRs
Resolves: CASMCMS-7753

* Change will also be needed in `release/csm-1.0.?`

## Testing

### Tested on:
I tested this on Fanta.

### Test description:

I simulated a malfunctioning node refusing to power down by setting the CAPMC retries to one and its timeout to five seconds. This didn't give the node enough time to respond, so it appeared unhealthy. CAPMC returned an error for that node.

BOA caught the error and dealt with it appropriately, which in this case means it ignored it. BOA then attempted to forcefully power the node off after the appropriate delay.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Was upgrade tested? If not, why? No, it wasn't.  This is going to basically replace the older BOA docker image with a newer one. An upgrade/downgrade test did not seem necessary.

## Risks and Mitigations

There are no known issues with this change.


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

