### PR TITLE
CASMCMS-7939: Use the versioned endpoints for CAPMC

### DIFF
--- a/src/cray/boa/capmcclient.py
+++ b/src/cray/boa/capmcclient.py
@@ -33,7 +33,8 @@ from cray.boa.connection import requests_retry_session
 
 LOGGER = logging.getLogger(__name__)
 SERVICE_NAME = 'cray-capmc'
-ENDPOINT = "%s://%s/capmc" % (PROTOCOL, SERVICE_NAME)
+CAPMC_VERSION = 'v1'
+ENDPOINT = "%s://%s/capmc/%s" % (PROTOCOL, SERVICE_NAME, CAPMC_VERSION)
 
 
 class CapmcException(TransientException):


### PR DESCRIPTION
## Summary and Scope

CAPMC deleted its non-versioned endpoint leaving us with only the
versioned endpoints. BOS will now use the versioned endpoint.

This is backwards compatible.
## Issues and Related PRs
CASMCMS-7939

## Testing

_List the environments in which these changes were tested._

### Tested on:

  * Mug

### Test description:

I tested a similar change within the BOS server code and ported it over to BOA.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? No
- Were continuous integration tests run? If not, why? I tested that BOS could talk with CAPMC.
- Was upgrade tested? If not, why? No
- Was downgrade tested? If not, why? No
- Were new tests (or test issues/Jiras) created for this change? No

## Risks and Mitigations
Low.


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

