### PR TITLE
CAST-29856: Correct misplaced parenthesis

### DIFF
--- a/src/cray/boa/smd/wait_for_nodes.py
+++ b/src/cray/boa/smd/wait_for_nodes.py
@@ -195,7 +195,7 @@ def wait_for_state(nodes, state, duration=70, interval=5, session=None, invert=F
                        mismatch_count, desired_state, ', '.join(sorted(state_mismatch)[:5]))
     else:
         LOGGER.warning("%s nodes failed to enter state '%s'; %s..." ,
-                       mismatch_count, desired_state, ', '.join(sorted(state_mismatch[:5])))
+                       mismatch_count, desired_state, ', '.join(sorted(state_mismatch)[:5]))
     if nodecount_in_desired_state >= minimum_required_success:
         return state_mismatch
     else:


### PR DESCRIPTION
## Summary and Scope

A parenthesis was misplaced causing the code to suscript a set, which is
not allowed. Moved the parenthesis to the correct location.

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves CAST-29856

## Testing

_List the environments in which these changes were tested._

### Tested on:


### Test description:

I tested this in a pod on Hela. I faked my way through it with pdb and saw that it worked.
- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why?
- Was upgrade tested? If not, why?
- Was downgrade tested? If not, why?
- Were new tests (or test issues/Jiras) created for this change?

## Risks and Mitigations

Low. The error message was already broken.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

