### PR TITLE
CASMCMS-7448: Use V2 endpoints for hardware state manager

### DIFF
--- a/src/cray/boa/smd/__init__.py
+++ b/src/cray/boa/smd/__init__.py
@@ -29,6 +29,5 @@ Created on Apr 26, 2019
 
 from cray.boa import PROTOCOL
 SERVICE_NAME = 'cray-smd'
-ENDPOINT = "%s://%s/hsm/v1/" % (PROTOCOL, SERVICE_NAME)
-
+ENDPOINT = "%s://%s/hsm/v2/" % (PROTOCOL, SERVICE_NAME)
 

--- a/src/cray/boa/smd/smdclient.py
+++ b/src/cray/boa/smd/smdclient.py
@@ -40,7 +40,8 @@ from cray.boa.logutil import call_logger
 
 LOGGER = logging.getLogger(__name__)
 SERVICE_NAME = 'cray-smd'
-ENDPOINT = "%s://%s/hsm/v1/" % (PROTOCOL, SERVICE_NAME)
+ENDPOINT = "%s://%s/hsm/v2/" % (PROTOCOL, SERVICE_NAME)
+
 
 @call_logger
 def node_map(key, node_list, session=None):


### PR DESCRIPTION
## Summary and Scope

Move from using the v1 endpoint to the v2 endpoints for the hardware
state manager.



## Issues and Related PRs


* Resolves CASMCMS-7448
* Change will also be needed in `<insert branch name here>`
* Future work required by [issue id](issue link)
* Documentation changes required in [issue id](issue link)
* Merge with/before/after `<insert PR URL here>`

## Testing

_List the environments in which these changes were tested._

### Tested on:

  * Hela
  * Local development environment
  * Virtual Shasta

### Test description:

i just jumped into the BOS pod and made sure that the v2 endpoint existed and was accessible.
- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why?
- Was upgrade tested? If not, why?
- Was downgrade tested? If not, why?
- Were new tests (or test issues/Jiras) created for this change?

## Risks and Mitigations

Low.


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

