### PR TITLE
CASMCMS-7972:  Update to use internal HPE network

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
---index-url https://arti.dev.cray.com:443/artifactory/api/pypi/pypi-remote/simple
 -c constraints.txt
 boto3
 etcd3


### PR DESCRIPTION
## Summary and Scope

Changing the reference from arti.dev.cray.com to
arti.hpc.amslabs.hpecorp.net


## Issues and Related PRs


* Resolves [CASMCMS-7972]

## Testing


### Tested on:

  * Mug
  * 
### Test description:

I pushed the new image into Nexus and launched a BOS V1 reboot of node 1. I watched BOA successfully reboot the node.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why?
- Was upgrade tested? If not, why?
- Was downgrade tested? If not, why?
- Were new tests (or test issues/Jiras) created for this change?

## Risks and Mitigations

Low

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

