### PR TITLE
CASMCMS-7551

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Updated deprecation warnings for use of nid based calls to capmc
+- Switch preflight check URI for capmc
 - Pin to later version of Alpine. Update Python 3 dependencies.
 - Initial implementation @jsollom-hpe
 

--- a/src/cray/boa/capmcclient.py
+++ b/src/cray/boa/capmcclient.py
@@ -27,7 +27,7 @@ import requests
 import json
 from collections import defaultdict
 
-from cray.boa import TransientException, PROTOCOL
+from cray.boa import TransientException, PROTOCOL, ServiceError
 from cray.boa.logutil import call_logger
 from cray.boa.connection import requests_retry_session
 
@@ -49,7 +49,7 @@ class CapmcTimeoutException(CapmcException):
     """
 
 
-class CapmcDeprecationException(CapmcException):
+class CapmcDeprecationException(ServiceError):
     """
     All or part of a request cannot be completed because it requires functionality
     that has been effectively deprecated out of a major version of capmc.

--- a/src/cray/boa/capmcclient.py
+++ b/src/cray/boa/capmcclient.py
@@ -49,6 +49,13 @@ class CapmcTimeoutException(CapmcException):
     """
 
 
+class CapmcDeprecationException(CapmcException):
+    """
+    All or part of a request cannot be completed because it requires functionality
+    that has been effectively deprecated out of a major version of capmc.
+    """
+
+
 def status(nodes, filtertype='show_all', session=None):
     """
     For a given iterable of nodes, represented by xnames, query CAPMC for
@@ -192,6 +199,10 @@ def power(nodes, state, force=True, session=None, reason="BOA: Powering nodes"):
 
     session = session or requests_retry_session()
     prefix, output_format = node_type(nodes)
+    if output_format == 'nids':
+        raise CapmcDeprecationException("CAPMC deprecated power control for nid based entries; "
+                                        "please convert remaining session template references from "
+                                        "nids over to xnames.")
     power_endpoint = '%s/%s_%s' % (ENDPOINT, prefix, state)
 
     if state == "on":

--- a/src/cray/boa/preflight.py
+++ b/src/cray/boa/preflight.py
@@ -133,7 +133,7 @@ class PreflightCheck(object):
         return self.check_uri(CFS_ENDPOINT)
 
     def check_capmc(self):
-        return self.check_uri(os.path.join(CAPMC_ENDPOINT, 'get_node_rules'),)
+        return self.check_uri(os.path.join(CAPMC_ENDPOINT, 'health'),)
 
     def check_smd(self):
         return self.check_uri(os.path.join(SMD_ENDPOINT, 'groups'),)


### PR DESCRIPTION
## Summary and Scope

CAPMC is deprecating functionality within a major release branch. This change adds a deprecation notice for session templates that explicitly call out nid values as static members, or for code that references the capmc power functions using an explicit set of nids (note: we normally only use xnames). Also updates the URI for health check of capmc for preflight checks.

## Issues and Related PRs

* Resolves [CASMCMS-7551](https://jira-pro.its.hpecorp.net:8443/browse/CASMCMS-7551)

## Testing

Built a new BOA Image and tested do-no-harm functionality.

### Tested on:

  * `groot`

### Test description:

Uploaded newly built image and updated chart reference. Created a BOS job to power off a node.

## Risks and Mitigations

Low risk.

## Pull Request Checklist

- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
