### PR TITLE
CASMTRIAGE-5404: Update message to use --template-name instead of --template-uuid in CLI command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Update message to use --template-name instead of --template-uuid in CLI command.
 
 ## [1.4.1] - 2023-05-18
 ### Changed

--- a/src/cray/boa/agent.py
+++ b/src/cray/boa/agent.py
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2019-2022 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2019-2023 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -614,7 +614,7 @@ class BootSetAgent(object):
                 return
             LOGGER.error("These nodes failed to {}. {}".format(self.operation, self.failed_nodes))
             LOGGER.error("You can attempt to {0} these nodes by issuing the command:\n"
-                         "cray bos v1 session create --template-uuid {1} --operation {0} --limit {2}".format(
+                         "cray bos v1 session create --template-name {1} --operation {0} --limit {2}".format(
                          self.operation, self.session_template_id, ','.join(self.failed_nodes)))
 
         with self.boot_set_status:


### PR DESCRIPTION
## Summary and Scope

Although the CLI claims either one should work, the uuid version does not. I'm still investigating why that is the case, but regardless, BOA may as well not tell users to use the deprecated option.

## Issues and Related PRs

* Partly resolves [CASMTRIAGE-5404](https://jira-pro.its.hpecorp.net:8443/browse/CASMTRIAGE-5404)

## Testing

It's just a message text change, so I'm just making sure the build works.

## Risks and Mitigations

Very low risk.

## Pull Request Checklist

- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [X] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable
