### PR TITLE
Update Jenkinsfile to reduce chances of hung or failed builds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+### Changed
+- Disabled concurrent Jenkins builds on same branch/commit
+- Added build timeout to avoid hung builds
+
 ## [1.4.3] - 2023-07-18
 ### Dependencies
 - Bump `PyYAML` from 6.0 to 6.0.1 to avoid build issue caused by https://github.com/yaml/pyyaml/issues/601

--- a/Jenkinsfile.github
+++ b/Jenkinsfile.github
@@ -33,6 +33,8 @@ pipeline {
 
     options {
         buildDiscarder(logRotator(numToKeepStr: "10"))
+        disableConcurrentBuilds()
+        timeout(time: 90, unit: 'MINUTES')
         timestamps()
     }
 


### PR DESCRIPTION
Based on a suggestion made by David, this updates the Jenkinsfile to effect two changes:
- Disable concurrent builds of the same tag or commit
- Add a timeout (90 minutes) as a safeguard against hung builds

These options are used in many other repos in our org to good effect.