### PR TITLE
CASMCMS-8274: Gracefully handle CAPMC locked node error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Removed nonexistent argument from docstring of `graceful_shutdown` function
   in `capmcclient.py`.
+- CASMCMS-8274: Treat CAPMC node lock errors as immediate failures, rather than waiting to eventually
+  fail due to timeout.
 
 ## [1.4.3] - 2023-07-18
 ### Dependencies


### PR DESCRIPTION
If BOA asks CAPMC to power on or off a list of xnames, and one of those xnames is locked in HSM, then CAPMC just returns with a specific error saying that it was unable to reserve the nodes. However, BOA interprets this as a non-fatal error, even though CAPMC has done no power operations. The result is that the BOA operations on those nodes eventually times out and fails.

This PR modifies it so that when CAPMC returns such an error, it interprets that as a failure for any nodes that are not explicitly reported by CAPMC as failing for some other reason. This in turn has the effect that they still fail (like before), but much faster, without having to wait for a timeout.

I've tested this on wasp and verified that it works as expected.